### PR TITLE
feat: Implement flash messages for admin area

### DIFF
--- a/main.py
+++ b/main.py
@@ -278,7 +278,7 @@ def download_abrechnungen():
             download_name="abrechnungen.csv"
         )
     else:
-        flash("Die Datei 'abrechnungen.csv' wurde nicht gefunden.")
+        flash("Die Datei 'abrechnungen.csv' wurde nicht gefunden.", "error")
         return redirect(url_for("index"))
 
 
@@ -388,7 +388,7 @@ def index():
         pdf_file = generate_pdf_receipt(data_dict)
         create_invoice_with_attachment(Path(pdf_file), bezahlter_betrag, zahlungsmethode.lower() == "bar", name)
         flash(
-            f"Abrechnung gespeichert! bezahlter Betrag: {bezahlter_betrag:.2f} €, Spende: {spende:.2f}, Rechnungsnr.: {rechnungsnummer}. PDF: {os.path.basename(pdf_file)}")
+            f"Abrechnung gespeichert! bezahlter Betrag: {bezahlter_betrag:.2f} €, Spende: {spende:.2f}, Rechnungsnr.: {rechnungsnummer}. PDF: {os.path.basename(pdf_file)}", "success")
         return redirect(url_for("index"))
 
     return render_template("index.html", price_data=price_data)
@@ -575,14 +575,14 @@ def delete_entry():
     rechnungsnummer = request.form.get("rechnungsnummer")
 
     if not timestamp:
-        flash("Kein Zeitstempel angegeben.")
+        flash("Kein Zeitstempel angegeben.", "error")
         return redirect(url_for("admin"))
 
     try:
         dt = datetime.datetime.strptime(timestamp, "%d.%m.%Y %H:%M:%S")
         pdf_name = dt.strftime("%d%m%Y%H%M%S") + ".pdf"
     except Exception:
-        flash("Ungültiges Datumsformat.")
+        flash("Ungültiges Datumsformat.", "error")
         return redirect(url_for("admin"))
 
     # 1. CSV neu schreiben ohne den zu löschenden Eintrag
@@ -616,7 +616,7 @@ def delete_entry():
     if os.path.exists(pdf_path):
         os.remove(pdf_path)
 
-    flash(f"Eintrag vom {timestamp} wurde gelöscht.")
+    flash(f"Eintrag vom {timestamp} wurde gelöscht.", "success")
     return redirect(url_for("admin"))
 
 
@@ -694,7 +694,7 @@ def download_pdf(filename):
             download_name=filename
         )
     else:
-        flash("Die PDF-Datei wurde nicht gefunden.")
+        flash("Die PDF-Datei wurde nicht gefunden.", "error")
         return redirect(url_for("admin"))
 
 

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -63,3 +63,42 @@ th, td {
 
 .row-0 { background-color: white; }
 .row-1 { background-color: #f0f0f0; }
+
+/* Flash messages styles */
+.flashes {
+  list-style-type: none;
+  padding: 0;
+  margin-bottom: 20px;
+}
+
+.flashes li {
+  padding: 15px;
+  margin-bottom: 10px;
+  border-radius: 5px;
+  font-size: 1.1em;
+  text-align: center;
+}
+
+.flash-success {
+  background-color: #d4edda; /* Light green */
+  color: #155724; /* Dark green */
+  border: 1px solid #c3e6cb;
+}
+
+.flash-error {
+  background-color: #f8d7da; /* Light red */
+  color: #721c24; /* Dark red */
+  border: 1px solid #f5c6cb;
+}
+
+.flash-info {
+  background-color: #d1ecf1; /* Light blue */
+  color: #0c5460; /* Dark blue */
+  border: 1px solid #bee5eb;
+}
+
+.flash-warning {
+  background-color: #fff3cd; /* Light yellow */
+  color: #856404; /* Dark yellow */
+  border: 1px solid #ffeeba;
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -9,6 +9,16 @@
   <div class="admin-container">
     <h1>Admin-Bereich - Abrechnungen</h1>
 
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        <ul class="flashes">
+        {% for category, message in messages %}
+          <li class="flash-{{ category }}">{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+
     <!-- Filterformular -->
     <form id="filter-form" method="GET" action="{{ url_for('admin') }}">
       <label for="from">Von:</label>


### PR DESCRIPTION
This commit introduces flash messages (success, error, info) to the admin interface.

Changes include:
- Modified `templates/admin.html` to render flashed messages with categories.
- Added CSS styles in `static/css/admin.css` for different message types (success, error, info, warning).
- Updated `main.py` to use message categories (e.g., "success", "error") in `flash()` calls for admin-related actions (delete, re-upload, PDF download errors). This ensures that feedback to you is clearly presented and styled.